### PR TITLE
feat: store messages

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,8 +8,9 @@ DB_USER=""
 DB_PASS=""
 DB_NAME="polinetwork_backend"
 
-# you generate it with `openssl rand -hex 20`
-BETTER_AUTH_SECRET=""
+ENCRYPTION_KEY="" # you generate it with `openssl rand -hex 32` !!! LENGTH IS IMPORTANT !!!
+
+BETTER_AUTH_SECRET="" # you generate it with `openssl rand -hex 20`
 # github provider https://www.better-auth.com/docs/authentication/github
 GITHUB_CLIENT_ID=""
 GITHUB_CLIENT_SECRET=""

--- a/backend/drizzle/0002_chilly_molly_hayes.sql
+++ b/backend/drizzle/0002_chilly_molly_hayes.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "tg_messages" (
+	"chat_id" bigint NOT NULL,
+	"message_id" bigint NOT NULL,
+	"author_id" bigint NOT NULL,
+	"timestamp" timestamp NOT NULL,
+	"message" varchar(8704) NOT NULL,
+	"created_at" timestamp (3) DEFAULT now() NOT NULL,
+	CONSTRAINT "tg_messages_chat_id_message_id_pk" PRIMARY KEY("chat_id","message_id")
+);

--- a/backend/drizzle/meta/0002_snapshot.json
+++ b/backend/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,743 @@
+{
+  "id": "39142a22-69ce-4cd6-ae6a-e1a4ee8374f9",
+  "prevId": "ed4d5775-023a-4e4c-8ab4-c50106cd7efc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_accounts_user_id_auth_users_id_fk": {
+          "name": "auth_accounts_user_id_auth_users_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "auth_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_sessions_user_id_auth_users_id_fk": {
+          "name": "auth_sessions_user_id_auth_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "auth_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_sessions_token_unique": {
+          "name": "auth_sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_users": {
+      "name": "auth_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tg_id": {
+          "name": "tg_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tg_username": {
+          "name": "tg_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_users_email_unique": {
+          "name": "auth_users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verifications": {
+      "name": "auth_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tg_groups": {
+      "name": "tg_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tg_groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "telegram_id_idx": {
+          "name": "telegram_id_idx",
+          "columns": [
+            {
+              "expression": "telegram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tg_groups_telegram_id_unique": {
+          "name": "tg_groups_telegram_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "telegram_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tg_link": {
+      "name": "tg_link",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ttl": {
+          "name": "ttl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tg_username": {
+          "name": "tg_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tg_id": {
+          "name": "tg_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tg_link_user_id_auth_users_id_fk": {
+          "name": "tg_link_user_id_auth_users_id_fk",
+          "tableFrom": "tg_link",
+          "tableTo": "auth_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tg_link_tg_id_unique": {
+          "name": "tg_link_tg_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tg_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tg_messages": {
+      "name": "tg_messages",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(8704)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tg_messages_chat_id_message_id_pk": {
+          "name": "tg_messages_chat_id_message_id_pk",
+          "columns": [
+            "chat_id",
+            "message_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tg_group_admins": {
+      "name": "tg_group_admins",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_id": {
+          "name": "added_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_id_idx": {
+          "name": "user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tg_group_admins_user_id_group_id_pk": {
+          "name": "tg_group_admins_user_id_group_id_pk",
+          "columns": [
+            "user_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tg_permissions": {
+      "name": "tg_permissions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "added_by_id": {
+          "name": "added_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modified_by_id": {
+          "name": "modified_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tg_test": {
+      "name": "tg_test",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tg_test_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.web_test": {
+      "name": "web_test",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "web_test_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1744821501093,
       "tag": "0001_empty_menace",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1745104846515,
+      "tag": "0002_chilly_molly_hayes",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "PoliNetwork backend server",
   "private": true,
   "keywords": [],

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,7 @@
     "@t3-oss/env-core": "^0.12.0",
     "@trpc/server": "11.1.0",
     "better-auth": "^1.2.7",
+    "croner": "^9.0.0",
     "drizzle-orm": "^0.39.3",
     "hono": "^4.7.6",
     "pg": "^8.13.2",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       better-auth:
         specifier: ^1.2.7
         version: 1.2.7
+      croner:
+        specifier: ^9.0.0
+        version: 9.0.0
       drizzle-orm:
         specifier: ^0.39.3
         version: 0.39.3(@types/pg@8.11.11)(kysely@0.27.6)(pg@8.13.3)
@@ -921,6 +924,10 @@ packages:
   copy-anything@3.0.5:
     resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
     engines: {node: '>=12.13'}
+
+  croner@9.0.0:
+    resolution: {integrity: sha512-onMB0OkDjkXunhdW9htFjEhqrD54+M94i6ackoUkjHKbRnXdyEyKRelp4nJ1kAz32+s27jP1FsebpJCVl0BsvA==}
+    engines: {node: '>=18.0'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2076,6 +2083,8 @@ snapshots:
   copy-anything@3.0.5:
     dependencies:
       is-what: 4.1.16
+
+  croner@9.0.0: {}
 
   cross-spawn@7.0.6:
     dependencies:

--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -9,3 +9,5 @@ export const TRUSTED_ORIGINS = [
   "http://localhost:5174",
   "http://localhost:5175",
 ]
+
+export const MESSAGES_RETENTION_DAYS = 7

--- a/backend/src/cron.ts
+++ b/backend/src/cron.ts
@@ -1,0 +1,53 @@
+import { Cron } from "croner";
+import { logger } from "./logger";
+import { MESSAGES_RETENTION_DAYS } from "./constants";
+import { DB, SCHEMA } from "./db";
+import { lt } from "drizzle-orm";
+
+export function cron() {
+  new Cron("0 23 4 * * *", async () => {
+    logger.info("[CRON] start");
+    await cleanMessages();
+    await cleanLinkCodes();
+    logger.info("[CRON] end");
+  });
+
+  logger.info("[CRON] scheduled");
+}
+
+async function cleanLinkCodes() {
+  logger.info(`[CRON] START(cleanLinkCodes)`);
+
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  try {
+    const deleted = await DB.delete(SCHEMA.TG.link)
+      .where(lt(SCHEMA.TG.messages.createdAt, yesterday))
+      .returning();
+    logger.info(
+      `[CRON] END(cleanLinkCodes) deleted ${deleted.length} link code(s).`,
+    );
+  } catch (err) {
+    logger.error(err, "[CRON] cleanLinkCodes");
+  }
+}
+
+async function cleanMessages() {
+  logger.info(
+    `[CRON] START(cleanMessages) retention days = ${MESSAGES_RETENTION_DAYS}`,
+  );
+
+  const daysAgo = new Date();
+  daysAgo.setDate(daysAgo.getDate() - MESSAGES_RETENTION_DAYS);
+  try {
+    const deleted = await DB.delete(SCHEMA.TG.messages)
+      .where(lt(SCHEMA.TG.messages.timestamp, daysAgo))
+      .returning();
+    logger.info(
+      `[CRON] END(cleanMessages) deleted ${deleted.length} message(s).`,
+    );
+  } catch (err) {
+    logger.error(err, "[CRON] cleanMessages");
+  }
+}

--- a/backend/src/db/schema/tg/index.ts
+++ b/backend/src/db/schema/tg/index.ts
@@ -2,5 +2,6 @@ import * as groups from "./groups";
 import * as test from "./test";
 import * as permissions from "./permissions";
 import * as link from "./link";
+import * as messages from "./messages";
 
-export const schema = { ...groups, ...test, ...permissions, ...link };
+export const schema = { ...groups, ...test, ...permissions, ...link, ...messages };

--- a/backend/src/db/schema/tg/messages.ts
+++ b/backend/src/db/schema/tg/messages.ts
@@ -1,0 +1,20 @@
+import { timeColumns } from "@/db/columns";
+import { createTable } from "../create-table";
+import { bigint, primaryKey, timestamp, varchar } from "drizzle-orm/pg-core";
+
+export const messages = createTable.tg(
+  "messages",
+  {
+    chatId: bigint("chat_id", {
+      mode: "number",
+    }).notNull(),
+    messageId: bigint("message_id", {
+      mode: "number",
+    }).notNull(),
+    authorId: bigint("author_id", { mode: "number" }).notNull(),
+    timestamp: timestamp("timestamp").notNull(), // the telegram message timestamp
+    message: varchar("message", { length: 8704 }).notNull(),
+    createdAt: timeColumns.createdAt,
+  },
+  (t) => [primaryKey({ columns: [t.chatId, t.messageId] })],
+);

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -17,6 +17,11 @@ export const env = createEnv({
     DB_PASS: z.string().min(1),
     DB_NAME: z.string().min(3).default("polinetwork_backend"),
     PUBLIC_URL: z.string().default(`http://localhost:${PORT}`),
+    ENCRYPTION_KEY: z
+      .string()
+      .regex(/^[A-Fa-f0-9]+$/, "The string must be a valid hex string")
+      .length(64),
+
     TRUSTED_ORIGINS: z
       .string()
       .default(TRUSTED_ORIGINS.join(","))
@@ -27,7 +32,6 @@ export const env = createEnv({
   },
 
   runtimeEnv: process.env,
-
   /**
    * By default, this library will feed the environment variables directly to
    * the Zod validator.

--- a/backend/src/routers/tg/index.ts
+++ b/backend/src/routers/tg/index.ts
@@ -2,9 +2,11 @@ import { createTRPCRouter } from "@/trpc";
 import groups from "./groups";
 import permissions from "./permissions";
 import link from "./link";
+import messages from "./messages";
 
 export const tgRouter = createTRPCRouter({
   groups,
   permissions,
   link,
+  messages,
 });

--- a/backend/src/routers/tg/messages.ts
+++ b/backend/src/routers/tg/messages.ts
@@ -1,0 +1,94 @@
+import { DB, SCHEMA } from "@/db";
+import { logger } from "@/logger";
+import { createTRPCRouter, publicProcedure } from "@/trpc";
+import { decrypt, encrypt } from "@/utils/encrypt";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+const s = SCHEMA.TG;
+const message = z.object({
+  chatId: z.number(),
+  messageId: z.number(),
+  authorId: z.number(),
+  message: z.string(),
+  timestamp: z.date(),
+});
+type Message = z.infer<typeof message>;
+
+function padChatId(chatId: number): number {
+  if (chatId < 0) return chatId;
+
+  const str = chatId.toString();
+  if (str.length === 13) return -chatId;
+
+  const padding = "1" + "0".repeat(12 - str.length);
+
+  // Prepend the padding to the input string
+  return parseInt(`-${padding}${chatId}`);
+}
+
+export default createTRPCRouter({
+  get: publicProcedure
+    .input(z.object({ chatId: z.number(), messageId: z.number() }))
+    .output(
+      z.union([
+        z.object({ message, error: z.null() }),
+        z.object({
+          message: z.null(),
+          error: z.enum(["NOT_FOUND", "DECRYPT_ERROR"]),
+        }),
+      ]),
+    )
+    .query(async ({ input }) => {
+      const [res] = await DB.select()
+        .from(s.messages)
+        .where(
+          and(
+            eq(s.messages.chatId, padChatId(input.chatId)),
+            eq(s.messages.messageId, input.messageId),
+          ),
+        )
+        .limit(1);
+
+      if (!res) return { message: null, error: "NOT_FOUND" };
+
+      try {
+        const encryptedMessage = await decrypt(res.message);
+        const message: Message = {
+          message: encryptedMessage,
+          timestamp: res.timestamp,
+          authorId: res.authorId,
+          chatId: res.chatId,
+          messageId: res.messageId,
+        };
+
+        return { message, error: null };
+      } catch (err) {
+        logger.error(err, "error while decrypting a telegram message");
+        return { message: null, error: "DECRYPT_ERROR" };
+      }
+    }),
+
+  add: publicProcedure
+    .input(z.object({ messages: z.array(message) }))
+    .output(z.object({ error: z.union([z.null(), z.enum(["ENCRYPT_ERROR"])]) }))
+    .mutation(async ({ input }) => {
+      try {
+        const messages = input.messages.map(async (m) => ({
+          ...m,
+          message: await encrypt(m.message),
+        }));
+        const awaitedMessages = await Promise.all(messages);
+        await DB.insert(s.messages)
+          .values(awaitedMessages)
+          .onConflictDoNothing();
+        return { error: null };
+      } catch (err) {
+        logger.error(
+          err,
+          `error while encrypting ${input.messages.length > 1 ? "some telegram messages" : "a telegam message"}`,
+        );
+        return { error: "ENCRYPT_ERROR" };
+      }
+    }),
+});

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -9,6 +9,7 @@ import { env } from "./env";
 import { logger } from "./logger";
 import { trpcServer } from "@hono/trpc-server";
 import { auth } from "./auth";
+import { cron } from "./cron";
 
 const app = new Hono();
 const isDev = env.NODE_ENV === "development";
@@ -54,6 +55,7 @@ app.get("/", (c) => c.text("hi"));
     const q1 = await DB.select().from(SCHEMA.TG.test);
     const q2 = await DB.select().from(SCHEMA.WEB.test);
     logger.info({ q1, q2 }, "db working:");
+    cron()
   } catch (err) {
     logger.error(err);
     process.exit(1);

--- a/backend/src/trpc.ts
+++ b/backend/src/trpc.ts
@@ -1,12 +1,14 @@
 import { initTRPC, TRPCError } from "@trpc/server";
 import { ZodError } from "zod";
 import { logger } from "./logger";
+import superjson from "superjson";
 
 type Context = {
-  userId?: string
-}
+  userId?: string;
+};
 
 const t = initTRPC.context<Context>().create({
+  transformer: superjson,
   errorFormatter({ shape, error }) {
     return {
       ...shape,

--- a/backend/src/utils/encrypt.ts
+++ b/backend/src/utils/encrypt.ts
@@ -1,0 +1,86 @@
+import { env } from '@/env';
+import { createCipheriv, createDecipheriv, randomBytes, CipherGCMTypes } from 'crypto';
+
+// Define your encryption algorithm and key size
+const ALGORITHM: CipherGCMTypes = 'aes-256-gcm'; // Using AES-256 in GCM mode
+const KEY_SIZE = 32; // 256 bits for AES-256
+const IV_SIZE = 12; // Standard size for AES-GCM IV
+
+// Ensure the key is the correct size and in a usable format (Buffer)
+const ENCRYPTION_KEY_BUFFER = Buffer.from(env.ENCRYPTION_KEY, 'hex');
+if (ENCRYPTION_KEY_BUFFER.length !== KEY_SIZE) {
+  throw new Error('Invalid encryption key size.');
+}
+
+/**
+ * Encrypts a string with aes-256-gcm.
+ *
+ * @param text The message content to encrypt.
+ * @returns A promise that resolves with the encrypted string (hexadecimal).
+ * @throws Error if encryption fails
+ */
+export async function encrypt(text: string): Promise<string> {
+  if (!text) {
+    return ''; // Handle empty strings gracefully
+  }
+
+  try {
+    const iv = randomBytes(IV_SIZE);
+    const cipher = createCipheriv(ALGORITHM, ENCRYPTION_KEY_BUFFER, iv);
+
+    let encrypted = cipher.update(text, 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+
+    // Get the authentication tag (required for GCM)
+    const tag = cipher.getAuthTag();
+
+    // Combine IV, encrypted text, and tag for storage.
+    // We use a separator to easily split them during decryption.
+    const encryptedPayload = iv.toString('hex') + ':' + encrypted + ':' + tag.toString('hex');
+    return encryptedPayload;
+
+  } catch (error) {
+    console.error('Encryption failed:', error);
+    throw new Error('Failed to encrypt message.');
+  }
+}
+
+/**
+ * Decrypts an encrypted string.
+ *
+ * @param encryptedPayload The encrypted content string (hexadecimal).
+ * @returns A promise that resolves with the decrypted message content.
+ * @throws Error if decryption fails.
+ */
+export async function decrypt(encryptedPayload: string): Promise<string> {
+  if (!encryptedPayload) {
+    return ''; // Handle empty strings gracefully
+  }
+
+  try {
+    const parts = encryptedPayload.split(':');
+    if (parts.length !== 3) {
+      throw new Error('Invalid encrypted payload format.');
+    }
+
+    const iv = Buffer.from(parts[0], 'hex');
+    const encryptedText = parts[1];
+    const tag = Buffer.from(parts[2], 'hex');
+
+    if (iv.length !== IV_SIZE) {
+      throw new Error('Invalid IV size during decryption.');
+    }
+
+    const decipher = createDecipheriv(ALGORITHM, ENCRYPTION_KEY_BUFFER, iv);
+    decipher.setAuthTag(tag); // Set the authentication tag
+
+    let decrypted = decipher.update(encryptedText, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+
+    return decrypted;
+
+  } catch (error: any) {
+    console.error('Decryption failed:', error.message);
+    throw new Error('Failed to decrypt message.');
+  }
+}

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polinetwork/backend",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "Utils to interact with the backend.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
features:
- automatic deletion after configured retention days
- encryption and decryption on the db column for message content
- pad the chatId to parse links like https://t.me/c/chat_id/msg_id where chat_id is a positive integer instead of a -100... integer

notes;
- add superjson as trpc transformer
- add cronjob also for link codes deletion (see previous commits)

not implemented:
- threads messages